### PR TITLE
Add logger, testing framework and assertion library

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,5 +3,9 @@
   "plugins": [
     "import"
   ],
-  "require-parems": "always"
+  "require-parems": "always",
+  "env": {
+    "node": true,
+    "mocha": true
+  }
 }

--- a/README.md
+++ b/README.md
@@ -35,3 +35,12 @@ $ npm start
 ```
 
 Visit http://localhost:3000/ to see "Welcome to the InScope Backend Application" message.
+
+## Testing
+
+Mocha is the test framework used in testing this application and Chai is the assertion library used.
+
+Run:
+```bash
+$ npm test
+```

--- a/bin/www
+++ b/bin/www
@@ -8,7 +8,7 @@ const app = require('../app');
 const debug = require('debug')('express-sequelize');
 const http = require('http');
 const models = require('../models');
-
+const winston = require('winston');
 
 /**
  * Normalize a port into a number, string, or false.
@@ -71,11 +71,11 @@ const onError = (error) => {
   // handle specific listen errors with friendly messages
   switch (error.code) {
     case 'EACCES':
-      console.error(`${bind} requires elevated privileges`);
+      winston.log('error', `${bind} requires elevated privileges`);
       process.exit(1);
       break;
     case 'EADDRINUSE':
-      console.error(`${bind} is already in use`);
+      winston.log('error', `${bind} is already in use`);
       process.exit(1);
       break;
     default:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "pg": "^6.1.5",
     "pg-hstore": "^2.3.2",
     "sequelize": "^3.30.4",
-    "serve-favicon": "~2.4.2"
+    "serve-favicon": "~2.4.2",
+    "winston": "^2.3.1"
   },
   "devDependencies": {
     "eslint": "^3.19.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "lint": "eslint *.js migrations/*.js models/*.js routes/*.js seeders/*.js bin/www"
+    "lint": "eslint *.js migrations/*.js models/*.js routes/*.js seeders/*.js bin/www",
+    "test": "mocha"
   },
   "dependencies": {
     "body-parser": "~1.17.1",
@@ -19,9 +20,11 @@
     "winston": "^2.3.1"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.1.3",
     "eslint-plugin-import": "^2.2.0",
+    "mocha": "^3.3.0",
     "pre-commit": "^1.2.2",
     "sequelize-cli": "^2.7.0"
   },

--- a/test/example.js
+++ b/test/example.js
@@ -1,0 +1,11 @@
+const chai = require('chai');
+
+const expect = chai.expect;
+
+describe('Array', () => {
+  describe('#indexOf()', () => {
+    it('should return -1 when the value is not present', () => {
+      expect([1, 2, 3].indexOf(4)).to.equal(-1);
+    });
+  });
+});


### PR DESCRIPTION
Adding Winston logging library, Mocha testing framework, and Chai assertion library to the backend application.

I'm planning on adding the Jasmine testing framework to the frontend application and this Mocha and Chai should appear similar when writing tests. An example test is added to `test/example.js`. It can be removed when tests are implemented.